### PR TITLE
[FEATURE] Add default empty backend layouts for TYPO3’s default doktypes

### DIFF
--- a/Configuration/PageTS/main.tsconfig
+++ b/Configuration/PageTS/main.tsconfig
@@ -1,0 +1,58 @@
+mod.web_layout.BackendLayouts {
+  DefaultLink {
+    title = LLL:EXT:doktypemapper/Resources/Private/Language/locallang_db.xlf:backend_layout.3.title
+    config.backend_layout {
+      doktype = 3
+      colCount = 0
+      rowCount = 0
+    }
+  }
+  DefaultShortcut {
+    title = LLL:EXT:doktypemapper/Resources/Private/Language/locallang_db.xlf:backend_layout.4.title
+    config.backend_layout {
+      doktype = 4
+      colCount = 0
+      rowCount = 0
+    }
+  }
+  DefaultBackendusersection {
+    title = LLL:EXT:doktypemapper/Resources/Private/Language/locallang_db.xlf:backend_layout.6.title
+    config.backend_layout {
+      doktype = 6
+      colCount = 0
+      rowCount = 0
+    }
+  }
+  DefaultMountpoint {
+    title = LLL:EXT:doktypemapper/Resources/Private/Language/locallang_db.xlf:backend_layout.7.title
+    config.backend_layout {
+      doktype = 7
+      colCount = 0
+      rowCount = 0
+    }
+  }
+  DefaultSpacer {
+    title = LLL:EXT:doktypemapper/Resources/Private/Language/locallang_db.xlf:backend_layout.199.title
+    config.backend_layout {
+      doktype = 199
+      colCount = 0
+      rowCount = 0
+    }
+  }
+  DefaultFolder {
+    title = LLL:EXT:doktypemapper/Resources/Private/Language/locallang_db.xlf:backend_layout.254.title
+    config.backend_layout {
+      doktype = 254
+      colCount = 0
+      rowCount = 0
+    }
+  }
+  DefaultRecycler {
+    title = LLL:EXT:doktypemapper/Resources/Private/Language/locallang_db.xlf:backend_layout.255.title
+    config.backend_layout {
+      doktype = 255
+      colCount = 0
+      rowCount = 0
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ TCEFORM.pages.backend_layout.disabled = 1
 TCEFORM.pages.backend_layout_next_level.disabled = 1
 ```
 
+### Note
+
+This extension comes with a default empty backend_layout configuration (see `Configuration/PageTs/main.tsconfig`) for
+TYPO3's default "empty" page types (like Shortcut, External Link, etc.) to ensure valid database entries for every page
+type (even the ones without any content).
+
+
 ## Credits
 
 This extension was created by Achim Fritz in 2021 for [b13 GmbH, Stuttgart](https://b13.com).

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" datatype="plaintext" original="messages" date="2024-13-13T13:13:13Z">
+		<header>
+			<description>Language Labels for EXT:doktypemapper</description>
+			<authorName>David Steeb</authorName>
+			<authorEmail>typo3@b13.com</authorEmail>
+		</header>
+		<body>
+			<trans-unit id="backend_layout.3.title">
+				<source>Empty Page (External Link)</source>
+			</trans-unit>
+			<trans-unit id="backend_layout.4.title">
+				<source>Empty Page (Shortcut)</source>
+			</trans-unit>
+			<trans-unit id="backend_layout.6.title">
+				<source>Empty Page (Backend User Section)</source>
+			</trans-unit>
+			<trans-unit id="backend_layout.7.title">
+				<source>Empty Page (Mountpoint)</source>
+			</trans-unit>
+			<trans-unit id="backend_layout.199.title">
+				<source>Empty Page (Spacer)</source>
+			</trans-unit>
+			<trans-unit id="backend_layout.254.title">
+				<source>Empty Page (Folder)</source>
+			</trans-unit>
+			<trans-unit id="backend_layout.255.title">
+				<source>Empty Page (Recycler)</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
If the editor changes a default page to one of the "non content TYPO3 default page types" like "Shortcut" or "External Link", the value for `backend_layout` is not changed and may reflect an invalid Backend Layout, allowing editors to add content to pages that will never show. This might be a valid feature in some instances, depending on the configuration, but as a default settings, these doktypes should not display any content area in the backend's page module.

This change adds default, empty Backend Layouts to all of TYPO3's default function doktypes. 